### PR TITLE
Upgrade React version compatibility to 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sunsama/react-simple-dropdown",
-  "version": "3.2.4",
+  "version": "3.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sunsama/react-simple-dropdown",
-      "version": "3.2.4",
+      "version": "3.2.6",
       "license": "ISC",
       "dependencies": {
         "classnames": "^2.1.2",
@@ -31,8 +31,8 @@
         "mkdirp": "^0.5.1",
         "ncp": "^2.0.0",
         "npm-run-all": "^1.4.0",
-        "react": "16.x",
-        "react-dom": "16.x",
+        "react": "18.x",
+        "react-dom": "18.x",
         "react-highlight": "^0.9.0",
         "sane": "^1.4.1",
         "simple-mock": "0.8.0",
@@ -42,8 +42,8 @@
         "zuul": "^3.11.1"
       },
       "peerDependencies": {
-        "react": "0.14.x || 15.x || 16.x",
-        "react-dom": "0.14.x || 15.x || 16.x"
+        "react": "0.14.x || 15.x || 16.x || 17.x || 18.x",
+        "react-dom": "0.14.x || 15.x || 16.x || 17.x || 18.x"
       }
     },
     "node_modules/@meadow/eslint-config": {
@@ -208,6 +208,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -9944,32 +9945,31 @@
       }
     },
     "node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "^16.14.0"
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-highlight": {
@@ -9988,6 +9988,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-15.7.0.tgz",
       "integrity": "sha512-5/MMRYmpmM0sMTHGLossnJCrmXQIiJilD6y3YN3TzAwGFj6zdnMtFv6xmi65PHKRV+pehIHpT7oy67Sr6s9AHA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "create-react-class": "^15.6.0",
         "fbjs": "^0.8.9",
@@ -10864,13 +10865,13 @@
       "dev": true
     },
     "node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/semver": {
@@ -14669,6 +14670,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -22947,26 +22949,23 @@
       }
     },
     "react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
+      "peer": true,
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
+        "loose-envify": "^1.1.0"
       }
     },
     "react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
+        "scheduler": "^0.23.2"
       }
     },
     "react-highlight": {
@@ -22985,6 +22984,7 @@
           "resolved": "https://registry.npmjs.org/react/-/react-15.7.0.tgz",
           "integrity": "sha512-5/MMRYmpmM0sMTHGLossnJCrmXQIiJilD6y3YN3TzAwGFj6zdnMtFv6xmi65PHKRV+pehIHpT7oy67Sr6s9AHA==",
           "dev": true,
+          "peer": true,
           "requires": {
             "create-react-class": "^15.6.0",
             "fbjs": "^0.8.9",
@@ -23706,13 +23706,12 @@
       "dev": true
     },
     "scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunsama/react-simple-dropdown",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "description": "Non-prescriptive React.js dropdown toolkit",
   "main": "lib/components/dropdown.js",
   "scripts": {
@@ -66,8 +66,8 @@
     "mkdirp": "^0.5.1",
     "ncp": "^2.0.0",
     "npm-run-all": "^1.4.0",
-    "react": "17.x",
-    "react-dom": "17.x",
+    "react": "18.x",
+    "react-dom": "18.x",
     "react-highlight": "^0.9.0",
     "sane": "^1.4.1",
     "simple-mock": "0.8.0",
@@ -77,7 +77,7 @@
     "zuul": "^3.11.1"
   },
   "peerDependencies": {
-    "react": "0.14.x || 15.x || 16.x || 17.x",
-    "react-dom": "0.14.x || 15.x || 16.x || 17.x"
+    "react": "0.14.x || 15.x || 16.x || 17.x || 18.x",
+    "react-dom": "0.14.x || 15.x || 16.x || 17.x || 18.x"
   }
 }


### PR DESCRIPTION
## Summary

Adds React 18 compatibility, mirroring the React 17 upgrade in c2ddf77.

- Bump `react` / `react-dom` devDependencies from `17.x` → `18.x`
- Add `18.x` to the `react` / `react-dom` peer dependency ranges
- Bump package version `3.2.5` → `3.2.6`
- Regenerate `package-lock.json` to resolve React 18.3.1 (the lock had been left stale at React 16 by the previous upgrade)

## Testing

The repo's `npm test` runs via `zuul` against SauceLabs, which requires cloud credentials that aren't available locally. To actually verify React 18 compatibility, the three test files (`test/components/*.jsx`) were run headlessly under Node with the built `lib/` output, jsdom, and the repo's babel presets against `react@18.3.1` / `react-dom@18.3.1`:

```
1..40
# tests 40
# pass  40
# ok
```

All 40 assertions pass. React logs the expected 18.x deprecation notices (legacy `ReactDOM.render`, `findDOMNode`, string refs) but there are no functional failures — the dropdown components render and behave correctly under React 18.

> Note: two pre-existing issues (unrelated to this change) surfaced while verifying and were **not** touched: the test files import PascalCase paths (`Dropdown.js`) that no longer match the kebab-case build output (`dropdown.js`), and the `electron@^1.6.2` devDependency has no arm64 build. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)